### PR TITLE
fix: deno.jsonc workspace setting

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,6 +13,6 @@
     "upgrade": "deno outdated --recursive --update"
   },
   "workspace": [
-    "./denops/@ddc-filters/converter_kind_labels"
+    "./denops/@ddc-filters/sorter_lsp_kind"
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed workspace setting in deno.jsonc
- Changed from incorrect `converter_kind_labels` to correct `sorter_lsp_kind`

## Changes
- Fixed the path in `workspace` array in `deno.jsonc`
- `./denops/@ddc-filters/converter_kind_labels` → `./denops/@ddc-filters/sorter_lsp_kind`

🤖 Generated with [Claude Code](https://claude.ai/code)